### PR TITLE
Support Application Security Group sources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_network_security_rule" "custom_rules" {
   source_port_ranges          = split(",", replace(lookup(var.custom_rules[count.index], "source_port_range", "*"), "*", "0-65535"))
   destination_port_ranges     = split(",", replace(lookup(var.custom_rules[count.index], "destination_port_range", "*"), "*", "0-65535"))
   source_address_prefix       = lookup(var.custom_rules[count.index], "source_address_prefix", "*")
-  source_application_security_group_ids = lookup(var.custom_rules[count.index], "source_application_security_group_ids", null)
+  source_application_security_group_ids = split(",", lookup(var.custom_rules[count.index], "source_application_security_group_ids", ""))
   destination_address_prefix  = lookup(var.custom_rules[count.index], "destination_address_prefix", "*")
   description                 = lookup(var.custom_rules[count.index], "description", "Security rule for ${lookup(var.custom_rules[count.index], "name", "default_rule_name")}")
   resource_group_name         = var.resource_group_name

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_network_security_rule" "custom_rules" {
   source_port_ranges          = split(",", replace(lookup(var.custom_rules[count.index], "source_port_range", "*"), "*", "0-65535"))
   destination_port_ranges     = split(",", replace(lookup(var.custom_rules[count.index], "destination_port_range", "*"), "*", "0-65535"))
   source_address_prefix       = lookup(var.custom_rules[count.index], "source_address_prefix", "*")
-  source_application_security_group_ids = split(",", lookup(var.custom_rules[count.index], "source_application_security_group_ids", ""))
+  source_application_security_group_ids = lookup(var.custom_rules[count.index], "source_application_security_group_ids", "") == "" ? null : split(",", lookup(var.custom_rules[count.index], "source_application_security_group_ids", ""))
   destination_address_prefix  = lookup(var.custom_rules[count.index], "destination_address_prefix", "*")
   description                 = lookup(var.custom_rules[count.index], "description", "Security rule for ${lookup(var.custom_rules[count.index], "name", "default_rule_name")}")
   resource_group_name         = var.resource_group_name

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ resource "azurerm_network_security_rule" "custom_rules" {
   source_port_ranges          = split(",", replace(lookup(var.custom_rules[count.index], "source_port_range", "*"), "*", "0-65535"))
   destination_port_ranges     = split(",", replace(lookup(var.custom_rules[count.index], "destination_port_range", "*"), "*", "0-65535"))
   source_address_prefix       = lookup(var.custom_rules[count.index], "source_address_prefix", "*")
+  source_application_security_group_ids = lookup(var.custom_rules[count.index], "source_application_security_group_ids", null)
   destination_address_prefix  = lookup(var.custom_rules[count.index], "destination_address_prefix", "*")
   description                 = lookup(var.custom_rules[count.index], "description", "Security rule for ${lookup(var.custom_rules[count.index], "name", "default_rule_name")}")
   resource_group_name         = var.resource_group_name

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,8 @@ resource "azurerm_network_security_rule" "custom_rules" {
   protocol                    = lookup(var.custom_rules[count.index], "protocol", "*")
   source_port_ranges          = split(",", replace(lookup(var.custom_rules[count.index], "source_port_range", "*"), "*", "0-65535"))
   destination_port_ranges     = split(",", replace(lookup(var.custom_rules[count.index], "destination_port_range", "*"), "*", "0-65535"))
-  source_address_prefix       = lookup(var.custom_rules[count.index], "source_address_prefix", "*")
+  # If we set source application security groups, we cannot pass source address prefixes
+  source_address_prefix       = lookup(var.custom_rules[count.index], "source_application_security_group_ids", "") == "" ? lookup(var.custom_rules[count.index], "source_address_prefix", "*") : null
   source_application_security_group_ids = lookup(var.custom_rules[count.index], "source_application_security_group_ids", "") == "" ? null : split(",", lookup(var.custom_rules[count.index], "source_application_security_group_ids", ""))
   destination_address_prefix  = lookup(var.custom_rules[count.index], "destination_address_prefix", "*")
   description                 = lookup(var.custom_rules[count.index], "description", "Security rule for ${lookup(var.custom_rules[count.index], "name", "default_rule_name")}")


### PR DESCRIPTION
Allows the use of application security groups as sources in custom rules. Pass in a CSV string of ASG IDs to a custom_rule map. Will override source_address_prefix.